### PR TITLE
Adding CI to crystal-devel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,108 +1,34 @@
 version: 2
 jobs:
-  indigo:
+  crystal:
     docker:
-      - image: ros:indigo-perception
+      - image: ros:crystal-ros-base
     steps:
       - checkout
       - run:
           name: Set Up Container
           command: |
-            apt-get update -qq && apt-get install -y python-catkin-tools
-            source `find /opt/ros -name setup.bash | sort | head -1`
+            apt update -qq
+            source `find /opt/ros -maxdepth 2 -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y
-            cd ..
-            catkin init
-            catkin config --extend /opt/ros/$ROS_DISTRO -j 4 --cmake-args -DCMAKE_BUILD_TYPE=Release
       - run:
           name: Build
           command: |
             cd ..
-            catkin build --limit-status-rate 0.5
-      - run:
-          name: Lint
-          command: |
-            cd ..
-            catkin build velodyne_driver velodyne_laserscan velodyne_pointcloud --no-deps --make-args roslint
+            colcon build --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=Release
       - run:
           name: Run Tests
           command: |
-            source `find /opt/ros -name setup.bash | sort | head -1`
+            source `find /opt/ros -maxdepth 2 -name setup.bash | sort | head -1`
             cd ..
-            catkin run_tests --limit-status-rate 0.5
-            catkin_test_results
+            colcon test --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=Release
+            colcon test-result
     working_directory: ~/src
-
-  kinetic:
-    docker:
-      - image: ros:kinetic-perception
-    steps:
-      - checkout
-      - run:
-          name: Set Up Container
-          command: |
-            apt-get update -qq && apt-get install -y python-catkin-tools
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            rosdep install --from-paths . --ignore-src -y
-            cd ..
-            catkin init
-            catkin config --extend /opt/ros/$ROS_DISTRO -j 4 --cmake-args -DCMAKE_BUILD_TYPE=Release
-      - run:
-          name: Build
-          command: |
-            cd ..
-            catkin build --limit-status-rate 0.5
-      - run:
-          name: Lint
-          command: |
-            cd ..
-            catkin build velodyne_driver velodyne_laserscan velodyne_pointcloud --no-deps --make-args roslint
-      - run:
-          name: Run Tests
-          command: |
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            cd ..
-            catkin run_tests --limit-status-rate 0.5
-            catkin_test_results
-    working_directory: ~/src
-
-  melodic:
-    docker:
-      - image: ros:melodic-perception
-    steps:
-      - checkout
-      - run:
-          name: Set Up Container
-          command: |
-            apt-get update -qq && apt-get install -y python-catkin-tools
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            rosdep install --from-paths . --ignore-src -y
-            cd ..
-            catkin init
-            catkin config --extend /opt/ros/$ROS_DISTRO -j 4 --cmake-args -DCMAKE_BUILD_TYPE=Release
-      - run:
-          name: Build
-          command: |
-            cd ..
-            catkin build --limit-status-rate 0.5
-      - run:
-          name: Lint
-          command: |
-            cd ..
-            catkin build velodyne_driver velodyne_laserscan velodyne_pointcloud --no-deps --make-args roslint
-      - run:
-          name: Run Tests
-          command: |
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            cd ..
-            catkin run_tests --limit-status-rate 0.5
-            catkin_test_results
-    working_directory: ~/src
+    environment:
+      - MAKEFLAGS: -j4
 
 workflows:
   version: 2
   ros_build:
     jobs:
-      - indigo
-      - kinetic
-      - melodic
+      - crystal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             colcon test-result
     working_directory: ~/src
     environment:
-      - MAKEFLAGS: -j4
+      - MAKEFLAGS: -j4 
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           command: |
             apt update -qq
             source `find /opt/ros -maxdepth 2 -name setup.bash | sort | head -1`
+            git clone https://github.com/ros/diagnostics -b ros2-devel
             rosdep install --from-paths . --ignore-src -y
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: Set Up Container
           command: |
-            apt update -qq
+            apt update -qq && apt install -y python3-argcomplete python3-colcon-common-extensions
             source `find /opt/ros -maxdepth 2 -name setup.bash | sort | head -1`
             git clone https://github.com/ros/diagnostics -b ros2-devel
             rosdep install --from-paths . --ignore-src -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - run:
           name: Build
           command: |
+            source `find /opt/ros -maxdepth 2 -name setup.bash | sort | head -1`
             cd ..
             colcon build --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=Release
       - run:

--- a/velodyne/package.xml
+++ b/velodyne/package.xml
@@ -16,9 +16,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>velodyne_driver</exec_depend>
-  <exec_depend>velodyne_laserscan</exec_depend>
+  <!--<exec_depend>velodyne_laserscan</exec_depend>-->
   <exec_depend>velodyne_msgs</exec_depend>
-  <exec_depend>velodyne_pointcloud</exec_depend>
+  <!--<exec_depend>velodyne_pointcloud</exec_depend>-->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/velodyne_driver/package.xml
+++ b/velodyne_driver/package.xml
@@ -25,7 +25,7 @@
     <build_depend>diagnostic_updater</build_depend>
     <build_depend>libpcap</build_depend>
     <build_depend>pluginlib</build_depend>
-    <build_depend>console_bridge</build_depend>
+    <build_depend>libconsole-bridge-dev</build_depend>
     <build_depend>tf2</build_depend>
     <build_depend>velodyne_msgs</build_depend>
     <build_depend>diagnostic_msgs</build_depend>
@@ -35,7 +35,7 @@
     <exec_depend>diagnostic_updater</exec_depend>
     <exec_depend>libpcap</exec_depend>
     <exec_depend>pluginlib</exec_depend>
-    <exec_depend>console_bridge</exec_depend>
+    <exec_depend>libconsole-bridge-dev</exec_depend>
     <exec_depend>tf2</exec_depend>
     <exec_depend>velodyne_msgs</exec_depend>
     <exec_depend>diagnostic_msgs</exec_depend>

--- a/velodyne_msgs/CMakeLists.txt
+++ b/velodyne_msgs/CMakeLists.txt
@@ -7,7 +7,6 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-find_package(tinyxml2 REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)


### PR DESCRIPTION
I got CircleCI working for Crystal, at least to the point where it fails to build because of the dependency on `gtest`. In order to test for yourself, you'll need to create an account on CircleCI and add this repo as a project. By default, it will only build `master` so you'll need to make and push a change to this branch in order for it to start building. If you have any questions about CircleCI or the CI process, let me know.